### PR TITLE
Only run documentation website for `main` branch

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -2,7 +2,7 @@ name: Deploy Documentation Website
 
 on: 
   push:
-    branches: ["main", "develop"] # remove "develop" for prod
+    branches: ["main"] # remove "develop" for prod
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Prevents overwrites our documentation page when pushing to develop

This reverts commit 09b32a6ea598636422dd802214682ab530ad82c3.